### PR TITLE
Integrate price feeder

### DIFF
--- a/scripts/chain/shutdown_nodes.sh
+++ b/scripts/chain/shutdown_nodes.sh
@@ -29,6 +29,8 @@ if [ $FILES_EXISTS == "true" ]; then
     do
         sudo -S systemctl stop $DAEMON-${a}.service
         echo "-- Stopped $DAEMON-${a}.service --"
+        sudo -S systemctl stop $DAEMON-${a}-pf.service
+        echo "-- Stopped $DAEMON-${a}-pf.service --"
     done
     echo "------- Running unsafe reset all ---------"
     for (( a=1; a<=$NUM_VALS; a++ ))
@@ -42,6 +44,8 @@ if [ $FILES_EXISTS == "true" ]; then
     do
     sudo -S systemctl disable $DAEMON-${a}.service
     echo "-- Executed sudo -S systemctl disable $DAEMON-${a}.service --"
+    sudo -S systemctl disable $DAEMON-${a}-pf.service
+    echo "-- Executed sudo -S systemctl disable $DAEMON-${a}-pf.service --"
     done
 else
     echo "----No simd services running-----"

--- a/scripts/chain/start_chain.sh
+++ b/scripts/chain/start_chain.sh
@@ -235,3 +235,104 @@ do
     echo "INFO: Checking $DAEMON_HOME-${a} chain status"
     $DAEMON status --node tcp://localhost:${RPC}
 done
+
+
+# create systemd service for each price feeder instance
+
+cd $REPO/price-feeder/
+make install
+cd $CURPATH
+
+for (( a=1; a<=$NUM_VALS; a++ ))
+do
+    DIFF=$(($a - 1))
+    INC=$(($DIFF * 2))
+    RPC=$((16657 + $INC))
+
+    pfconfig="${DAEMON_HOME}-${a}/price-feeder/config.toml"
+
+    mkdir -p "${DAEMON_HOME}-${a}/price-feeder"
+    touch $pfconfig
+
+    UMEE_E2E_PRICE_FEEDER_VALIDATOR="umeed keys show validator${a} --home "${DAEMON_HOME}-${a}" --bech val --keyring-backend test --output json | jq .address
+    UMEE_E2E_PRICE_FEEDER_ADDRESS="umeed keys show validator${a} --home "${DAEMON_HOME}-${a}" --bech acc --keyring-backend test --output json | jq .address
+    UMEE_E2E_UMEE_VAL_KEY_DIR="${DAEMON_HOME}-${a}"
+    UMEE_E2E_UMEE_VAL_HOST="tcp://localhost:${RPC}"
+
+    # setup price-feeder configuration
+    tee $pfconfig <<EOF
+    gas_adjustment = 1.5
+    provider_timeout = "5000ms"
+    [server]
+    listen_addr = "0.0.0.0:7171"
+    read_timeout = "20s"
+    verbose_cors = true
+    write_timeout = "20s"
+    [[currency_pairs]]
+    base = "UMEE"
+    providers = [
+    "mock",
+    ]
+    quote = "USDT"
+    [[currency_pairs]]
+    base = "ATOM"
+    providers = [
+    "mock",
+    ]
+    quote = "USDC"
+    [[currency_pairs]]
+    base = "USDC"
+    providers = [
+    "mock",
+    ]
+    quote = "USD"
+    [[currency_pairs]]
+    base = "USDT"
+    providers = [
+    "mock",
+    ]
+    quote = "USD"
+    [account]
+    address = '$UMEE_E2E_PRICE_FEEDER_ADDRESS'
+    chain_id = "umee-local-testnet"
+    validator = '$UMEE_E2E_PRICE_FEEDER_VALIDATOR'
+    [keyring]
+    backend = "test"
+    dir = '$UMEE_E2E_UMEE_VAL_KEY_DIR'
+    [rpc]
+    grpc_endpoint = 'tcp://$UMEE_E2E_UMEE_VAL_HOST:9090'
+    rpc_timeout = "100ms"
+    tmrpc_endpoint = 'http://$UMEE_E2E_UMEE_VAL_HOST:26657'
+    [telemetry]
+    service-name = "price-feeder"
+    enabled = true
+    enable-hostname = true
+    enable-hostname-label = true
+    enable-service-label = true
+    type = "prometheus"
+    global-labels = [["chain-id", "test"]]
+EOF
+
+    echo "INFO: Creating price-feeder $DAEMON-$a systemd service file"
+    echo "[Unit]
+    Description=${DAEMON}-price-feeder daemon
+    After=network.target
+    [Service]
+    Environment="DAEMON_HOME=$DAEMON_HOME-$a"
+	Environment="DAEMON_NAME=$DAEMON"
+	Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
+	Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+	Environment="UNSAFE_SKIP_BACKUP=false"
+    Type=simple
+    User=$USER
+    ExecStart=$(which price-feeder) $pfconfig
+    Restart=on-failure
+    RestartSec=3
+    LimitNOFILE=4096
+    [Install]
+    WantedBy=multi-user.target" | sudo tee "/lib/systemd/system/$DAEMON-${a}-pf.service"
+    echo "INFO: Starting $DAEMON-${a}-pf service"
+    sudo -S systemctl daemon-reload
+    sudo -S systemctl start $DAEMON-${a}-pf.service
+    sleep 3s
+done

--- a/scripts/chain/start_chain.sh
+++ b/scripts/chain/start_chain.sh
@@ -254,15 +254,15 @@ do
     PF_CONFIG="${CONFIG_DIR}/price-feeder.toml"
     cp ../configs/price-feeder.toml $CONFIG_DIR
 
-    UMEE_E2E_PRICE_FEEDER_VALIDATOR=$(eval "umeed keys show validator${a} --home ${DAEMON_HOME}-${a} --bech val --keyring-backend test --output json | jq .address")
-    UMEE_E2E_PRICE_FEEDER_ADDRESS=$(eval "umeed keys show validator${a} --home ${DAEMON_HOME}-${a} --bech acc --keyring-backend test --output json | jq .address")
-    UMEE_E2E_UMEE_VAL_KEY_DIR="${DAEMON_HOME}-${a}"
-    UMEE_E2E_UMEE_VAL_HOST="tcp://localhost:${RPC}"
+    PRICE_FEEDER_VALIDATOR=$(eval "umeed keys show validator${a} --home ${DAEMON_HOME}-${a} --bech val --keyring-backend test --output json | jq .address")
+    PRICE_FEEDER_ADDRESS=$(eval "umeed keys show validator${a} --home ${DAEMON_HOME}-${a} --bech acc --keyring-backend test --output json | jq .address")
+    UMEE_VAL_KEY_DIR="${DAEMON_HOME}-${a}"
+    UMEE_VAL_HOST="tcp://localhost:${RPC}"
 
     sed -i "s/\$PF_PORT/${PF_PORT}/g" $PF_CONFIG
-    sed -i "s/\"\$UMEE_E2E_PRICE_FEEDER_VALIDATOR\"/${UMEE_E2E_PRICE_FEEDER_VALIDATOR}/g" $PF_CONFIG
-    sed -i "s/\"\$UMEE_E2E_PRICE_FEEDER_ADDRESS\"/${UMEE_E2E_PRICE_FEEDER_ADDRESS}/g" $PF_CONFIG
-    sed -i "s|\"\$UMEE_E2E_UMEE_VAL_KEY_DIR\"|\"${UMEE_E2E_UMEE_VAL_KEY_DIR}\"|g" $PF_CONFIG
+    sed -i "s/\"\$PRICE_FEEDER_VALIDATOR\"/${PRICE_FEEDER_VALIDATOR}/g" $PF_CONFIG
+    sed -i "s/\"\$PRICE_FEEDER_ADDRESS\"/${PRICE_FEEDER_ADDRESS}/g" $PF_CONFIG
+    sed -i "s|\"\$UMEE_VAL_KEY_DIR\"|\"${UMEE_VAL_KEY_DIR}\"|g" $PF_CONFIG
     sed -i "s/\$GRPC/${GRPC}/" $PF_CONFIG
     sed -i "s/\$RPC/${RPC}/" $PF_CONFIG
 

--- a/scripts/configs/price-feeder.toml
+++ b/scripts/configs/price-feeder.toml
@@ -1,0 +1,50 @@
+gas_adjustment = 1.5
+provider_timeout = "5000ms"
+[server]
+listen_addr = "0.0.0.0:$PF_PORT"
+read_timeout = "20s"
+verbose_cors = true
+write_timeout = "20s"
+[[currency_pairs]]
+base = "UMEE"
+providers = [
+"mock",
+]
+quote = "USDT"
+[[currency_pairs]]
+base = "ATOM"
+providers = [
+"mock",
+]
+quote = "USDC"
+[[currency_pairs]]
+base = "USDC"
+providers = [
+"mock",
+]
+quote = "USD"
+[[currency_pairs]]
+base = "USDT"
+providers = [
+"mock",
+]
+quote = "USD"
+[account]
+address = "$UMEE_E2E_PRICE_FEEDER_ADDRESS"
+chain_id = "test"
+validator = "$UMEE_E2E_PRICE_FEEDER_VALIDATOR"
+[keyring]
+backend = "test"
+dir = "$UMEE_E2E_UMEE_VAL_KEY_DIR"
+[rpc]
+grpc_endpoint = "tcp://localhost:$GRPC"
+rpc_timeout = "100ms"
+tmrpc_endpoint = "http://localhost:$RPC"
+[telemetry]
+service_name = "price-feeder"
+enabled = true
+enable_hostname = true
+enable_hostname_label = true
+enable_service_label = true
+type = "prometheus"
+global_labels = [["chain-id", "test"]]

--- a/scripts/configs/price-feeder.toml
+++ b/scripts/configs/price-feeder.toml
@@ -30,12 +30,12 @@ providers = [
 ]
 quote = "USD"
 [account]
-address = "$UMEE_E2E_PRICE_FEEDER_ADDRESS"
+address = "$PRICE_FEEDER_ADDRESS"
 chain_id = "test"
-validator = "$UMEE_E2E_PRICE_FEEDER_VALIDATOR"
+validator = "$PRICE_FEEDER_VALIDATOR"
 [keyring]
 backend = "test"
-dir = "$UMEE_E2E_UMEE_VAL_KEY_DIR"
+dir = "$UMEE_VAL_KEY_DIR"
 [rpc]
 grpc_endpoint = "tcp://localhost:$GRPC"
 rpc_timeout = "100ms"

--- a/scripts/deps/prereq.sh
+++ b/scripts/deps/prereq.sh
@@ -12,9 +12,9 @@ CURPATH=`dirname $(realpath "$0")`
 cd $CURPATH
 source ../../env
 
-if command_exists go ; then
-  echo "Golang is already installed"
-else
+# if command_exists go ; then
+#   echo "Golang is already installed"
+# else
   sudo rm -rf /usr/local/go
   echo "Install dependencies"
   sudo apt update
@@ -31,7 +31,7 @@ else
   echo "" >> ~/.bashrc
   echo 'export GOROOT=/usr/local/go' >> ~/.bashrc
   source ~/.bashrc
-fi
+# fi
 which go
 go version
 

--- a/scripts/deps/prereq.sh
+++ b/scripts/deps/prereq.sh
@@ -12,9 +12,9 @@ CURPATH=`dirname $(realpath "$0")`
 cd $CURPATH
 source ../../env
 
-# if command_exists go ; then
-#   echo "Golang is already installed"
-# else
+if command_exists go ; then
+  echo "Golang is already installed"
+else
   sudo rm -rf /usr/local/go
   echo "Install dependencies"
   sudo apt update
@@ -31,7 +31,7 @@ source ../../env
   echo "" >> ~/.bashrc
   echo 'export GOROOT=/usr/local/go' >> ~/.bashrc
   source ~/.bashrc
-# fi
+fi
 which go
 go version
 


### PR DESCRIPTION
- Added functionality to the start-chain bash script that creates a new price-feeder service alongside any umeed service that is created.
- Each new price-feeder service has a number associated with it just like the umeed services that are created where umeed-1 is the node that umeed-1-pf sends its price transactions to.