### PR TITLE
feat: Use delegate accounts for price-feeder tx

### DIFF
--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -1,0 +1,20 @@
+name: Oracle Module
+#  Oracle Module workflow tests the oracle module
+#  This workflow run on pushes to master, workflow_dispatch & on every pull request
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  oracle-module:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: test oracle module
+        run: |
+          make test-oracle-module
+        env:
+          IS_PUBLIC: false

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ lint: install-deps
 	PYTHONPATH=./internal pylint ./internal
 
 setup-chain: install-deps stop-chain
-	@bash ./scripts/chain/start_chain.sh 2
+	@bash ./scripts/chain/start_chain.sh 5
+	@echo "Waiting for chain to start..."
+	@sleep 7
+
+setup-chain-no-pf: install-deps stop-chain
+	@bash ./scripts/chain/start_chain.sh 3 false
 	@echo "Waiting for chain to start..."
 	@sleep 7
 
@@ -59,7 +64,7 @@ test-leverage-module: setup-chain
 	TEST_TYPE=leverage-module bash ./scripts/tests/leverage_module.sh
 	$(MAKE) stop-chain
 
-test-oracle-module: setup-chain
+test-oracle-module: setup-chain-no-pf
 	@echo "Running oracle module tests..."
 	TEST_TYPE=oracle-module bash ./scripts/tests/oracle_module.sh
 	$(MAKE) stop-chain

--- a/scripts/chain/helpers/services.sh
+++ b/scripts/chain/helpers/services.sh
@@ -8,45 +8,47 @@ command_exists () {
   type "$1" &> /dev/null ;
 }
 
-service_exists() {
+service_running() {
   local service=$1
-  if [[ $(systemctl list-units --all -t service --full --no-legend "$service" | sed 's/^\s*//g' | cut -f1 -d' ') == $service ]]; then
+  if [[ $(systemctl list-units --all -t service --full --no-legend "$service.service" | sed 's/^\s*//g' | cut -f1 -d' ') == $service.service ]]; then
     return 0
   else
     return 1
   fi
 }
 
+service_exists() {
+  [ $(systemctl list-unit-files "${1}*" | wc -l) -gt 3 ]
+}
+
 disable_service() {
   local service=$1
-
   if service_exists $service; then
-    sudo -S systemctl disable $service.service
-    echo "-- Executed sudo -S systemctl disable $service.service --"
+    sudo -S systemctl disable $service
+    echo "-- Executed sudo -S systemctl disable $service --"
   fi
 }
 
 stop_service() {
   local service=$1
-
-  if service_exists $service; then
+  if service_running $service; then
     sudo -S systemctl stop $service
-    echo "-- Executed sudo -S systemctl stop $service.service --"
+    echo "-- Executed sudo -S systemctl stop $service --"
   fi
 }
 
 restart_service() {
   local service=$1
 
-  sudo -S systemctl restart $service.service
-  echo "-- Executed sudo -S systemctl restart $service.service --"
+  sudo -S systemctl restart $service
+  echo "-- Executed sudo -S systemctl restart $service --"
 }
 
 start_service() {
   local service=$1
 
-  sudo -S systemctl start $service.service
-  echo "-- Executed sudo -S systemctl start $service.service --"
+  sudo -S systemctl start $service
+  echo "-- Executed sudo -S systemctl start $service --"
 }
 
 daemon_reload() {

--- a/scripts/chain/pause_nodes.sh
+++ b/scripts/chain/pause_nodes.sh
@@ -20,8 +20,8 @@ echo "---------- Stopping systemd service files --------"
 for (( a=1; a<=$NUM_VALS; a++ ))
 do
     if command_exists systemctl ; then
-        stop_service $DAEMON-${a}.service
-        stop_service $DAEMON-${a}-pf.service
+        stop_service $DAEMON-${a}
+        stop_service $DAEMON-${a}-pf
         continue
     fi
 

--- a/scripts/chain/resume_nodes.sh
+++ b/scripts/chain/resume_nodes.sh
@@ -16,8 +16,8 @@ echo "---------- Restarting systemd service files --------"
 for (( a=1; a<=$NUM_VALS; a++ ))
 do
     if command_exists systemctl ; then
-        restart_service $DAEMON-${a}.service
-        restart_service $DAEMON-${a}-pf.service
+        restart_service $DAEMON-${a}
+        restart_service $DAEMON-${a}-pf
         continue
     fi
 

--- a/scripts/chain/shutdown_nodes.sh
+++ b/scripts/chain/shutdown_nodes.sh
@@ -30,12 +30,11 @@ done
 
 if [ $FILES_EXISTS == "true" ]; then
     echo "INFO: Number of validator nodes to be shutdown and disabled: $NUM_VALS"
-    echo "---------- Stopping $DAEMON-${a} --------"
     for (( a=1; a<=$NUM_VALS; a++ ))
     do
         if command_exists systemctl ; then
-            stop_service $DAEMON-${a}.service
-            stop_service $DAEMON-${a}-pf.service
+            stop_service $DAEMON-${a}
+            stop_service $DAEMON-${a}-pf
             continue
         fi
 

--- a/scripts/chain/start_chain.sh
+++ b/scripts/chain/start_chain.sh
@@ -238,7 +238,7 @@ do
 done
 
 if $ENABLE_PRICE_FEEDER; then
-    echo "Sleeping 5 seconds for account sync before price-feeder setup"
+    echo "Sleeping 10 seconds for account sync before price-feeder setup"
     sleep 10
     for (( a=1; a<=$NUM_VALS; a++ ))
     do


### PR DESCRIPTION
- Added a delegate-feed-consent CLI call for each price-feeder validator (fixes acoount sequence mismatch error)
- Added option to disable the price-feeder when calling setup-chain. The PF needs to be turned off when running the oracle tests and probably some others or else you will get duplicate pre-votes/votes. All 3 price-feeders need to be running for leverage tests so the only other option would be to add more nodes.
- Added github workflow for the oracle module tests