### PR TITLE
Fix shutdown script for pid

### DIFF
--- a/scripts/chain/helpers/daemons.sh
+++ b/scripts/chain/helpers/daemons.sh
@@ -43,7 +43,7 @@ start_price_feeder() {
   # Setup delegated price-feeder account
   ACCT_NUM=$(($VAL_NUM + 2))
   ACCT_ADDR=$($DAEMON keys show account$ACCT_NUM -a --home $DAEMON_HOME-1 --keyring-backend test)
-  $DAEMON tx oracle delegate-feed-consent validator$VAL_NUM $ACCT_ADDR --keyring-backend test --from $alidator$VAL_NUM \
+  $DAEMON tx oracle delegate-feed-consent validator$VAL_NUM $ACCT_ADDR --keyring-backend test \
     --chain-id $CHAINID --home $DAEMON_HOME-$VAL_NUM --gas 2000000 --node tcp://localhost:${RPC} -y
 
   if command_exists systemctl ; then

--- a/scripts/chain/helpers/daemons.sh
+++ b/scripts/chain/helpers/daemons.sh
@@ -36,6 +36,10 @@ start_umeed() {
 start_price_feeder() {
   VAL_NUM=$1
 
+  DIFF=$(($VAL_NUM - 1))
+  INC=$(($DIFF * 2))
+  RPC=$((16657 + $INC))
+
   # Setup delegated price-feeder account
   ACCT_NUM=$(($VAL_NUM + 2))
   ACCT_ADDR=$($DAEMON keys show account$ACCT_NUM -a --home $DAEMON_HOME-1 --keyring-backend test)

--- a/scripts/chain/shutdown_nodes.sh
+++ b/scripts/chain/shutdown_nodes.sh
@@ -31,9 +31,11 @@ done
 echo "------- Running unsafe reset all ---------"
 for (( a=1; a<=$NUM_VALS; a++ ))
 do
-    $DAEMON tendermint unsafe-reset-all  --home $DAEMON_HOME-$a
+    if command_exists $DAEMON ; then
+        $DAEMON tendermint unsafe-reset-all  --home $DAEMON_HOME-$a
+        echo "-- Executed $DAEMON unsafe-reset-all  --home $DAEMON_HOME-$a --"
+    fi
     rm -rf $DAEMON_HOME-$a
-    echo "-- Executed $DAEMON unsafe-reset-all  --home $DAEMON_HOME-$a --"
 done
 
 if command_exists systemctl ; then


### PR DESCRIPTION
- Removed the unnecessary if statement surrounding the entire shutdown script that checks for the existence of the systemctl service file.
- Fixed the RPC address used by the delegate-feed-consent command